### PR TITLE
Starting with Docker 1.4.1, we need to force set the tag otherwise it fails

### DIFF
--- a/engine/build.go
+++ b/engine/build.go
@@ -329,8 +329,9 @@ func (b *Builder) MakeImage(dockerfile string, name ImageName, uptodate bool, no
 		for _, tag := range name.Tags {
 			// Tag Image
 			opts := dockerclient.TagImageOptions{
-				Tag:  tag,
-				Repo: name.Name,
+				Tag:   tag,
+				Repo:  name.Name,
+				Force: true,
 			}
 			if err := b.Client.TagImage(name.Name, opts); err != nil {
 				return err


### PR DESCRIPTION
Starting with Docker 1.4.1 we can't replace a existing tag without forcing it. This PR adds force to the tag call.
