### PR TITLE
useless assignment removed

### DIFF
--- a/engine/name.go
+++ b/engine/name.go
@@ -47,8 +47,6 @@ func (i *ImageName) ToHostname() (string, error) {
 	sp := strings.Split(tmp, "/")
 	if len(sp) == 2 {
 		tmp = sp[1]
-	} else {
-		tmp = tmp
 	}
 
 	// Now let's check branch


### PR DESCRIPTION
`go vet` was complaining about it:

```
$ go vet ./...
engine/name.go:51: self-assignment of tmp to tmp
exit status 1
```